### PR TITLE
Fix a bug while converting zim [[links]].

### DIFF
--- a/zim2markdown.py
+++ b/zim2markdown.py
@@ -547,7 +547,11 @@ class Zim2Markdown(object):
                     link_re=re.compile('(:|\\+|\\b)(.+)',re.X | re.M)
 
                 m1=link_re.match(link_text)
-                url,link=m1.groups()
+                if m1 == None:
+                    url = ""
+                    link = link_text
+                else:
+                    url,link=m1.groups()
 
                 ########## syntax: link ##############
                 result_head = '[%s]' % link


### PR DESCRIPTION
Hey,

Sometimes Zim is automatically creating links for unix filepaths and some others url-ish.
The zim to markdown converter was crashing on those, this is a small bugfix correctly creating markdown URLs, e.g.:

```
zim: My text [[/etc/fstab]]
md: My text [/etc/fstab](/etc/fstab)
````

I've used your project to convert my notes to Markdown so I thought I should send you this. You've probably forgot about your own project but heh, it was a lot of time saved for me so thanks for your work!