### PR TITLE
Update to Python 3.7 compatibility

### DIFF
--- a/lib/tools.py
+++ b/lib/tools.py
@@ -1,24 +1,22 @@
 '''
 Utility functions.
 
-Update time: 2016-03-24 11:11:46.
+Update time: 2019-09-27 19:59:00.
 '''
+from __future__ import print_function
+from __future__ import unicode_literals
 import os
 import re
 
 
 
 def deu(text):
-    if isinstance(text,str):
-        return text.decode('utf8','replace')
-    else:
-        return text
+    # TODO: delete, deprecated with Python > 3
+    return text
 
 def enu(text):
-    if isinstance(text,unicode):
-        return text.encode('utf8','replace')
-    else:
-        return text
+    # TODO: delete, deprecated with Python > 3
+    return text
 
 
 

--- a/markdown2zim.py
+++ b/markdown2zim.py
@@ -48,10 +48,18 @@ Syntax not supported:
     - tables
                      
 
-Update time: 2016-03-21 21:17:19.
+Update time: 2019-09-27 19:59:00.
 """
+from __future__ import print_function
+from __future__ import unicode_literals
 
 
+from builtins import bytes
+from builtins import str
+from builtins import zip
+from builtins import range
+from past.builtins import basestring
+from builtins import object
 import re
 import sys,os
 import argparse
@@ -72,7 +80,6 @@ if sys.version_info[0] <= 2:
     base_string_type = basestring
 elif sys.version_info[0] >= 3:
     py3 = True
-    unicode = str
     base_string_type = str
 
 
@@ -131,9 +138,6 @@ class Markdown2Zim(object):
         # one article (e.g. an index page that shows the N most recent
         # articles):
         self.reset()
-
-        if not isinstance(text, unicode):
-            text = unicode(text, 'utf-8')
 
         # Standardize line endings:
         text = re.sub("\r\n|\r", "\n", text)

--- a/test/test_zim2markdown.py
+++ b/test/test_zim2markdown.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import unicode_literals
 import zim2markdown
 
 text="""
@@ -47,6 +49,6 @@ code block continues.
 
 out2=zim2markdown.Zim2Markdown().convert(text)
 
-print text
-print '\n'
-print out2
+print(text)
+print('\n')
+print(out2)

--- a/zim2markdown.py
+++ b/zim2markdown.py
@@ -44,10 +44,17 @@ Syntax not supported:
     - tables
                      
 
-Update time: 2016-03-21 21:17:19.
+Update time: 2019-09-27 19:59:00.
 """
+from __future__ import print_function
+from __future__ import unicode_literals
 
 
+from builtins import bytes
+from builtins import str
+from builtins import range
+from past.builtins import basestring
+from builtins import object
 import re
 import sys,os
 import argparse
@@ -68,7 +75,6 @@ if sys.version_info[0] <= 2:
     base_string_type = basestring
 elif sys.version_info[0] >= 3:
     py3 = True
-    unicode = str
     base_string_type = str
 
 
@@ -178,9 +184,6 @@ class Zim2Markdown(object):
         # one article (e.g. an index page that shows the N most recent
         # articles):
         self.reset()
-
-        if not isinstance(text, unicode):
-            text = unicode(text, 'utf-8')
 
         # Standardize line endings:
         text = re.sub("\r\n|\r", "\n", text)


### PR DESCRIPTION
Quick and dirty update to Python 3.7 compatibility using futurize and some manual fixes and cleaning up. It seems to be working fine in both ways but I have only tested on a single case for the moment. But since the futurize process did not change the codebase that much (mostly removing conversion to utf8 since it's done by default and adding imports for Python 2 compatibility), I expect the code to work as it did before.